### PR TITLE
Playlist addition bug fixed

### DIFF
--- a/mysite/MusicApp/views.py
+++ b/mysite/MusicApp/views.py
@@ -309,9 +309,11 @@ def add_to_playlist(request):
 				playlist.save()
 				return HttpResponse("song added")
 			else:
+				"""
 				playlist.songs.add(song)
 				playlist.save()
-				return HttpResponse("song added")
+				"""
+				return HttpResponse("song is already present in the playlist")
 		else:
 			return HttpResponse("Playlist does not exist")
 


### PR DESCRIPTION
If song is already present in the playlist and he wants to add it again, it can't be added and simply show the message "song is already present in the playlist"
